### PR TITLE
calendar working

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,7 @@ class App extends React.Component {
       createEventDay: '',
       newEvent: '',
       newEventAddress: '',
+      today: '',
     };
 
     this.onInputChange = this.onInputChange.bind(this);
@@ -42,6 +43,7 @@ class App extends React.Component {
     // on init function to make get request to server
     // temp using 1234 as the timelineId and test as timelineName
     // this.getTrip();
+    this.setDate();
   }
 
   onInputChange(event) {
@@ -88,6 +90,14 @@ class App extends React.Component {
     if (event.key === 'Enter') {
       this.getTrip();
     }
+  }
+
+  setDate() {
+    let today = moment().format('L').split('/');
+    today = `${today[2]}-${today[0]}-${today[1]}`;
+    this.setState({
+      today,
+    });
   }
 
   getTrip() {
@@ -163,10 +173,12 @@ class App extends React.Component {
           <StartDateBox
             onInput={this.onInputChange}
             onEnter={this.onEnter}
+            today={this.state.today}
           />
           <EndDateBox
             onInput={this.onInputChange}
             onEnter={this.onEnter}
+            startDate={this.state.startDate}
           />
           <button
             className="scheduleSubmit"

--- a/client/src/EndDateBox.jsx
+++ b/client/src/EndDateBox.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import propTypes from 'prop-types';
 
-const EndDateBox = ({ onInput, onEnter }) => (
+const EndDateBox = ({ onInput, onEnter, startDate }) => (
   <div className="inputBox label">
     <label className="endDate" htmlFor="endDate">
       End Date:
       <input
         id="endDate"
-        type="text"
+        type="date"
+        min={startDate}
         name="endDate"
         onChange={event => onInput(event)}
         placeholder="enter an end date"
@@ -20,6 +21,7 @@ const EndDateBox = ({ onInput, onEnter }) => (
 EndDateBox.propTypes = {
   onInput: propTypes.func.isRequired,
   onEnter: propTypes.func.isRequired,
+  startDate: propTypes.string.isRequired,
 };
 
 export default EndDateBox;

--- a/client/src/StartDateBox.jsx
+++ b/client/src/StartDateBox.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import propTypes from 'prop-types';
 
-const StartDateBox = ({ onInput, onEnter }) => (
+
+const StartDateBox = ({ onInput, onEnter, today }) => (
   <div className="inputBox label">
     <label className="startDate" htmlFor="startDate">
     Start Date:
     <input
       id="startDate"
-      type="text"
+      type="date"
+      min={today}
       name="startDate"
       onChange={event => onInput(event)}
       placeholder="enter a start date"
@@ -20,6 +22,7 @@ const StartDateBox = ({ onInput, onEnter }) => (
 StartDateBox.propTypes = {
   onInput: propTypes.func.isRequired,
   onEnter: propTypes.func.isRequired,
+  today: propTypes.string.isRequired,
 };
 
 


### PR DESCRIPTION
This PR adds a calendar widget when the user clicks on the start date and end date fields. The start date is limited to todays date (you should not be able to plan a trips that would have already started) the end date is limited off of the start date. Todays date is set in the state of the app view and passed down as a prop.